### PR TITLE
return scaledVelocity and setHandleNoteOff velocity 0

### DIFF
--- a/note.cpp
+++ b/note.cpp
@@ -22,7 +22,7 @@ int Note::calculateVelocity(int midiVelocity) {
   } else if(scaledVelocity < NOTE_MIN_PWM) {
     return NOTE_MIN_PWM;
   } else {
-    return mappedVelocity;
+    return scaledVelocity;
   }
 }
 

--- a/player_piano.ino
+++ b/player_piano.ino
@@ -31,7 +31,7 @@ void setup() {
 
   // UPDATE: this needs to use the addToSchedule function
   MIDI.setHandleNoteOn([](uint8_t _, uint8_t noteId, uint8_t velocity) { piano.scheduleNote(noteId, velocity); });
-  MIDI.setHandleNoteOff([](uint8_t _, uint8_t noteId, uint8_t velocity) { piano.scheduleNote(noteId, velocity); });
+  MIDI.setHandleNoteOff([](uint8_t _, uint8_t noteId, uint8_t velocity) { piano.scheduleNote(noteId, 0); });
   MIDI.setHandleControlChange([](uint8_t channel, uint8_t number, uint8_t value) { piano.scheduleSustain(channel, number, value); });
 
   board1.begin(SDA_PIN, SCL_PIN, PCA9635_MODE1_NONE, PCA9635_MODE2_INVERT | PCA9635_MODE2_TOTEMPOLE);


### PR DESCRIPTION
Fixes 2 issues:
- return scaledVelocity in note.cpp to allow pot to better control the volume
- velocity set to 0 in scheduleNote for NOTE OFF midi messages in player_piano.ino to prevent "stuck" keys for any NOTE OFF midi messages with velocity > 0. 